### PR TITLE
Add -i, --initial and -d, --delay options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,6 +18,7 @@ Options:
   -h, --help               output usage information
   -p, --pattern <pattern>  glob pattern. More info: https://github.com/isaacs/minimatch
   -i  --initial            run <cmd> on initial startup
+  -d  --delay <n>          delay execution of <cmd> for a number of milliseconds
 
 
 Examples:

--- a/Readme.md
+++ b/Readme.md
@@ -17,6 +17,7 @@ Options:
 
   -h, --help               output usage information
   -p, --pattern <pattern>  glob pattern. More info: https://github.com/isaacs/minimatch
+  -i  --initial            run <cmd> on initial startup
 
 
 Examples:

--- a/bin/watch
+++ b/bin/watch
@@ -9,6 +9,7 @@ var debug = require('debug')('watch')
 var program = require('commander')
 var join = require('path').join
 var Gaze = require('gaze').Gaze
+var delay = 0;
 
 /**
  * Options.
@@ -18,6 +19,7 @@ program
   .usage('<cmd>')
   .option('-p, --pattern <pattern>', 'glob pattern. More info: https://github.com/isaacs/minimatch', 'lib/**')
   .option('-i, --initial', 'run <cmd> on initial startup', false)
+  .option('-d, --delay <n>', 'delay execution of <cmd> for a number of milliseconds', parseInt)
 
 /**
  * Examples.
@@ -60,6 +62,12 @@ if (program.initial) {
 }
 
 /**
+ * Set requested delay after initial execution.
+ */
+
+delay = program.delay || 0;
+
+/**
  * Execute command when file in dir changes.
  *
  * @param {String} event
@@ -67,9 +75,11 @@ if (program.initial) {
  */
 
 function execute (event, path) {
-  exec(command, function(err, stdout, stderr) {
-    if(err) throw err;
-    if(stderr) console.log(stderr);
-    if(stdout) console.log(stdout);
-  })
+  setTimeout(function () {
+    exec(command, function(err, stdout, stderr) {
+      if(err) throw err;
+      if(stderr) console.log(stderr);
+      if(stdout) console.log(stdout);
+    })
+  }, delay)
 }

--- a/bin/watch
+++ b/bin/watch
@@ -17,6 +17,7 @@ var Gaze = require('gaze').Gaze
 program
   .usage('<cmd>')
   .option('-p, --pattern <pattern>', 'glob pattern. More info: https://github.com/isaacs/minimatch', 'lib/**')
+  .option('-i, --initial', 'run <cmd> on initial startup', false)
 
 /**
  * Examples.
@@ -49,6 +50,14 @@ var command = program.args.join(' ')
 
 var watch = new Gaze(program.pattern)
 watch.on('all', execute)
+
+/**
+ * Run initial execution if required.
+ */
+
+if (program.initial) {
+  execute()
+}
 
 /**
  * Execute command when file in dir changes.


### PR DESCRIPTION
By using -i, --initial, you can make watch-run execute &lt;cmd&gt; when it first starts. This is helpful when &lt;cmd&gt; fails and next time you run watch-run you want it to run &lt;cmd&gt; right away.

By using -d, --delay &lt;n&gt;, you can make watch-run execute &lt;cmd&gt; &lt;n&gt; milliseconds after a change has been encountered.

Take if you like!