### PR TITLE
Add option to exit on errors (-s, --stop-on-error)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,7 +19,7 @@ Options:
   -p, --pattern <pattern>  glob pattern. More info: https://github.com/isaacs/minimatch
   -i  --initial            run <cmd> on initial startup
   -d  --delay <n>          delay execution of <cmd> for a number of milliseconds
-
+  -a  --allow-errors       allow errors to occur in <cmd> without exiting run-watch
 
 Examples:
 

--- a/Readme.md
+++ b/Readme.md
@@ -19,7 +19,7 @@ Options:
   -p, --pattern <pattern>  glob pattern. More info: https://github.com/isaacs/minimatch
   -i  --initial            run <cmd> on initial startup
   -d  --delay <n>          delay execution of <cmd> for a number of milliseconds
-  -a  --allow-errors       allow errors to occur in <cmd> without exiting run-watch
+  -s  --stop-on-error     stop watching and exit when errors occur in <cmd>
 
 Examples:
 

--- a/bin/watch
+++ b/bin/watch
@@ -19,7 +19,7 @@ program
   .usage('<cmd>')
   .option('-p, --pattern <pattern>', 'glob pattern. More info: https://github.com/isaacs/minimatch', 'lib/**')
   .option('-i, --initial', 'run <cmd> on initial startup', false)
-  .option('-d, --delay <n>', 'delay execution of <cmd> for a number of milliseconds', parseInt)
+  .option('-a, --allow-errors', 'allow errors to occur in <cmd> without exiting watch-run', false)
 
 /**
  * Examples.
@@ -77,7 +77,7 @@ delay = program.delay || 0;
 function execute (event, path) {
   setTimeout(function () {
     exec(command, function(err, stdout, stderr) {
-      if(err) throw err;
+      if(err && !program.allowErrors) throw err;
       if(stderr) console.log(stderr);
       if(stdout) console.log(stdout);
     })

--- a/bin/watch
+++ b/bin/watch
@@ -19,7 +19,7 @@ program
   .usage('<cmd>')
   .option('-p, --pattern <pattern>', 'glob pattern. More info: https://github.com/isaacs/minimatch', 'lib/**')
   .option('-i, --initial', 'run <cmd> on initial startup', false)
-  .option('-a, --allow-errors', 'allow errors to occur in <cmd> without exiting watch-run', false)
+  .option('-s, --stop-on-error', 'stop watching and exit when errors occur in <cmd>', false)
 
 /**
  * Examples.
@@ -77,7 +77,7 @@ delay = program.delay || 0;
 function execute (event, path) {
   setTimeout(function () {
     exec(command, function(err, stdout, stderr) {
-      if(err && !program.allowErrors) throw err;
+      if(err && program.stopOnErrors) throw err;
       if(stderr) console.log(stderr);
       if(stdout) console.log(stdout);
     })


### PR DESCRIPTION
Currently when an error occurs during the execution of &lt;cmd&gt; and an `err` is returned to the callback of `exec`, the error will be thrown and watch-run will exit. This new option (-a, --allow-errors) will enable watch-run to ignore the error and keep watching for changes. 