### PR TITLE
Readme: Change examples to  separate options and cmd with --

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,7 @@
 Via `--help`:
 
 ```
-Usage: watch-run <cmd>
+Usage: watch-run [options] -- <cmd>
 
 Options:
 
@@ -24,12 +24,12 @@ Options:
 Examples:
 
   # watch dir and execute cmd
-  $ watch-run -p 'lib/**' cat package.json
+  $ watch-run -p 'lib/**' -- cat package.json
 ```
 
 ## Example
 
-	$ watch-run -p 'js/modules/**/*.js' browserify main.js -o public/build.js
+	$ watch-run -p 'js/modules/**/*.js' -- browserify main.js -o public/build.js
 
 ## License
 


### PR DESCRIPTION
I wasted some time figuring out why the command didnt run correctly.

Without the `--`, this command will run, but missing flags/options.
`watch-run -i -- rsync -rv --update ./* user@host:/path`

Does `commander` strip all options?
`commander` already supports the `--` syntax, so no code change is needed.