### PR TITLE
Update gaze dep to v1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "watch-run": "bin/watch"
   },
   "dependencies": {
-    "gaze": "~0.4.3",
+    "gaze": "~1.1.2",
     "debug": "~0.7.4",
     "commander": "~2.1.0"
   },


### PR DESCRIPTION
Without this upgrade, Node keeps complaining about an outdated dependency that is no longer working in Node v7 - graceful-fs@1.2.3